### PR TITLE
feat: cicd to use npm read token instead of auth

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -42,7 +42,7 @@ on:
         required: false
       SONAR_TOKEN:
         required: false
-      NPM_AUTH_TOKEN:
+      NPM_READ_TOKEN:
         required: false
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
       - name: Setup access to Exporo NPM
         run: |
           echo "@exporo:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_READ_TOKEN }}" >> ~/.npmrc
       - name: Cache dependencies
         id: cache
         uses: actions/cache@v2
@@ -91,7 +91,7 @@ jobs:
       - name: Setup access to Exporo NPM
         run: |
           echo "@exporo:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_READ_TOKEN }}" >> ~/.npmrc
           
       - name: Cache dependencies
         id: cache
@@ -152,7 +152,7 @@ jobs:
       - name: Setup access to Exporo NPM
         run: |
           echo "@exporo:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_READ_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: npm ci
       - run: npm run build --if-present
@@ -205,7 +205,7 @@ jobs:
       - name: Setup access to Exporo NPM
         run: |
           echo "@exporo:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_READ_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         if: ${{ !inputs.DISABLE_STAGE }}
         run: npm ci
@@ -259,7 +259,7 @@ jobs:
       - name: Setup access to Exporo NPM
         run: |
           echo "@exporo:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" >> ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.NPM_READ_TOKEN }}" >> ~/.npmrc
       - name: Install dependencies
         run: npm ci
       - run: npm run build --if-present


### PR DESCRIPTION
## Changes
use `NPM_READ_TOKEN` instead of `NPM_AUTH_TOKEN` since we do not publish anything